### PR TITLE
Added Monster Closet Elements

### DIFF
--- a/MMLX 4.23/Content/Blueprints/MonsterCloset_BP.uasset
+++ b/MMLX 4.23/Content/Blueprints/MonsterCloset_BP.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:092ccdb169c41bdcc0da85338b2b9f668db34a9eb338363f2925f3aa7f63d416
+size 122308

--- a/MMLX 4.23/Content/StaticMeshes/Ruins/SM_MonsterCloset_DamagedDoor.uasset
+++ b/MMLX 4.23/Content/StaticMeshes/Ruins/SM_MonsterCloset_DamagedDoor.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8851f6b12a96a205c99de3ac499a2b97c8bf479ae10b4da3f538d171495a15dc
+size 330235

--- a/MMLX 4.23/Content/StaticMeshes/Ruins/SM_MonsterCloset_DoorBottom.uasset
+++ b/MMLX 4.23/Content/StaticMeshes/Ruins/SM_MonsterCloset_DoorBottom.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae64ae6001502bea450ed0a508e0927058bd1b49822a60d4296cae84242e5bd4
+size 135619

--- a/MMLX 4.23/Content/StaticMeshes/Ruins/SM_MonsterCloset_DoorTop.uasset
+++ b/MMLX 4.23/Content/StaticMeshes/Ruins/SM_MonsterCloset_DoorTop.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ed10925fe08db7e5965c37c0c6b4c5b0677c5e4e2b9fc4bcc5f4d4688fc5362a
+size 202332

--- a/MMLX 4.23/Content/StaticMeshes/Ruins/SM_MonsterCloset_Wall.uasset
+++ b/MMLX 4.23/Content/StaticMeshes/Ruins/SM_MonsterCloset_Wall.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:52aa65f56e3daef256e9596e6b56b55b7a272eb2ffbc13e7237dec5ab414c463
+size 160966


### PR DESCRIPTION
This commit contains 4 new models, and one Actor BP.

The Blueprint is just the compiled models, in their general proper positions. No Logic has been added yet.

The models are for the Door Top, Door Bottom, Wall, and damaged door, for when the spawn point has been 'destroyed'.

This should be enough to get the functional logic moving forward for these monster closets. We'll need to do FX and lots of other things eventually, but at least we can get the deployment working correctly. 